### PR TITLE
Force all actions to be non-blocking

### DIFF
--- a/lib/scamp/action.rb
+++ b/lib/scamp/action.rb
@@ -44,7 +44,7 @@ class Scamp
     end
     
     def run
-      self.instance_eval &@action
+      EM.defer { self.instance_eval &@action }
     end
     
     private


### PR DESCRIPTION
If actions are called directly from the main EM loop and you have a slow action, that isn't itself implemented in a  non-blocking fashion, this can cause the bot to disconnect from the room.

Wrapping every action in an EM.defer block fixes this (I think).
