### PR TITLE
Support for global required_prefix 

### DIFF
--- a/lib/scamp.rb
+++ b/lib/scamp.rb
@@ -15,7 +15,8 @@ class Scamp
   include Channels
   include Users
 
-  attr_accessor :channels, :user_cache, :channel_cache, :matchers, :api_key, :subdomain, :logger, :verbose, :first_match_only, :channels_to_join
+  attr_accessor :channels, :user_cache, :channel_cache, :matchers, :api_key, :subdomain,
+                :logger, :verbose, :first_match_only, :require_prefix, :channels_to_join
 
   def initialize(options = {})
     options ||= {}

--- a/lib/scamp.rb
+++ b/lib/scamp.rb
@@ -16,7 +16,7 @@ class Scamp
   include Users
 
   attr_accessor :channels, :user_cache, :channel_cache, :matchers, :api_key, :subdomain,
-                :logger, :verbose, :first_match_only, :require_prefix, :channels_to_join
+                :logger, :verbose, :first_match_only, :required_prefix, :channels_to_join
 
   def initialize(options = {})
     options ||= {}
@@ -74,7 +74,7 @@ class Scamp
 
   def match trigger, params={}, &block
     params ||= {}
-    matchers << Matcher.new(self, {:trigger => trigger, :action => block, :conditions => params[:conditions]})
+    matchers << Matcher.new(self, {:trigger => trigger, :action => block, :conditions => params[:conditions], :required_prefix => required_prefix})
   end
   
   def process_message(msg)

--- a/lib/scamp/matcher.rb
+++ b/lib/scamp/matcher.rb
@@ -26,7 +26,7 @@ class Scamp
     private
     
     def triggered_by(message_text)
-      if required_prefix
+      if required_prefix 
         message_text = handle_prefix(message_text)
         return false if message_text == false
       end
@@ -41,11 +41,7 @@ class Scamp
     end
     
     def handle_prefix(message_text)
-      bot.logger.warn "TEXT: #{message_text}"
-      bot.logger.warn "PREFIX: #{required_prefix}".inspect
-      
       if required_prefix.is_a? String
-        bot.logger.warn "GSUBD: "+ message_text[0...required_prefix.length]
         if required_prefix == message_text[0...required_prefix.length]
           message_text.gsub(required_prefix,'') 
         else
@@ -53,7 +49,6 @@ class Scamp
         end
       elsif required_prefix.is_a? Regexp
         if required_prefix.match message_text
-          bot.logger.warn "GSUBD"+message_text.gsub(required_prefix,'')
           message_text.gsub(required_prefix,'')
         else
           false

--- a/lib/scamp/matcher.rb
+++ b/lib/scamp/matcher.rb
@@ -41,7 +41,7 @@ class Scamp
     end
     
     def handle_prefix(message_text)
-      return false unles message_text
+      return false unless message_text
       if required_prefix.is_a? String
         if required_prefix == message_text[0...required_prefix.length]
           message_text.gsub(required_prefix,'') 

--- a/lib/scamp/matcher.rb
+++ b/lib/scamp/matcher.rb
@@ -26,9 +26,9 @@ class Scamp
     private
     
     def triggered_by(message_text)
-      if required_prefix 
+      if message_text && required_prefix 
         message_text = handle_prefix(message_text)
-        return false if message_text == false
+        return false unless message_text
       end
       if trigger.is_a? String
         return true if trigger == message_text
@@ -41,6 +41,7 @@ class Scamp
     end
     
     def handle_prefix(message_text)
+      return false unles message_text
       if required_prefix.is_a? String
         if required_prefix == message_text[0...required_prefix.length]
           message_text.gsub(required_prefix,'') 

--- a/lib/scamp/matcher.rb
+++ b/lib/scamp/matcher.rb
@@ -1,6 +1,6 @@
 class Scamp
   class Matcher
-    attr_accessor :conditions, :trigger, :action, :bot
+    attr_accessor :conditions, :trigger, :action, :bot, :required_prefix
     
     def initialize(bot, params = {})
       params ||= {}
@@ -26,6 +26,10 @@ class Scamp
     private
     
     def triggered_by(message_text)
+      if required_prefix
+        message_text = handle_prefix(message_text)
+        return false if message_text == false
+      end
       if trigger.is_a? String
         return true if trigger == message_text
       elsif trigger.is_a? Regexp
@@ -35,6 +39,29 @@ class Scamp
       end
       false
     end
+    
+    def handle_prefix(message_text)
+      bot.logger.warn "TEXT: #{message_text}"
+      bot.logger.warn "PREFIX: #{required_prefix}".inspect
+      
+      if required_prefix.is_a? String
+        bot.logger.warn "GSUBD: "+ message_text[0...required_prefix.length]
+        if required_prefix == message_text[0...required_prefix.length]
+          message_text.gsub(required_prefix,'') 
+        else
+          false
+        end
+      elsif required_prefix.is_a? Regexp
+        if required_prefix.match message_text
+          bot.logger.warn "GSUBD"+message_text.gsub(required_prefix,'')
+          message_text.gsub(required_prefix,'')
+        else
+          false
+        end
+      else
+        false
+      end
+    end 
     
     def run(msg, match = nil)
       action_run = Action.new(bot, action, msg)

--- a/spec/lib/scamp_spec.rb
+++ b/spec/lib/scamp_spec.rb
@@ -2,11 +2,11 @@ require "spec_helper"
 
 describe Scamp do
   before do
-    @valid_params = {:api_key => "6124d98749365e3db2c9e5b27ca04db6", :subdomain => "oxygen"}
+    @valid_params = {:api_key => "6124d98749365e3db2c9e5b27ca04db6", :subdomain => "oxygen"} 
     @valid_user_cache_data = {123 => {"name" => "foo"}, 456 => {"name" => "bar"}}
     @valid_channel_cache_data = {123 => {"name" => "foo"}, 456 => {"name" => "bar"}}
   end
-
+  
   describe "#initialize" do
     it "should work with valid params" do
       a(Scamp).should be_a(Scamp)
@@ -187,6 +187,7 @@ describe Scamp do
         
         bot.send(:process_message, {:body => "a string"})
       end
+      
     end
     
     describe "regexes" do
@@ -249,7 +250,7 @@ describe Scamp do
   def mock_logger
     @logger_string = StringIO.new
     @fake_logger = Logger.new(@logger_string)
-    Scamp.any_instance.should_receive(:logger).and_return(@fake_logger)
+    Scamp.any_instance.expects(:logger).returns(@fake_logger)
   end
 
   # Bleurgh

--- a/spec/lib/scamp_spec.rb
+++ b/spec/lib/scamp_spec.rb
@@ -188,8 +188,32 @@ describe Scamp do
         bot.send(:process_message, {:body => "a string"})
       end
       
+      it "should not match without prefix when required_prefix is true" do
+        canary = mock
+        canary.expects(:lives).never
+        
+        bot = a Scamp, :required_prefix => 'Bot: '
+        bot.behaviour do
+          match("a string") {canary.lives}
+        end
+        
+        bot.send(:process_message, {:body => "a string"})
+      end
+
+      it "should match with exact prefix when required_prefix is true" do
+        canary = mock
+        canary.expects(:lives).once
+        
+        bot = a Scamp, :required_prefix => 'Bot: '
+        bot.behaviour do
+          match("a string") {canary.lives}
+        end
+        
+        bot.send(:process_message, {:body => "Bot: a string"})
+      end
     end
     
+
     describe "regexes" do
       it "should match a regex" do
         canary = mock
@@ -236,6 +260,35 @@ describe Scamp do
         end
         
         bot.send(:process_message, {:body => "please match first and the rest of it"})
+      end
+      
+      it "should not match without prefix when required_prefix is present" do
+        canary = mock
+        canary.expects(:lives).never
+        
+        bot = a Scamp, :required_prefix => /^Bot[\:,\s]+/i
+        bot.behaviour do
+          match(/a string/) {canary.lives}
+        end
+        
+        bot.send(:process_message, {:body => "a string"})
+        bot.send(:process_message, {:body => "some kind of a string"})
+        bot.send(:process_message, {:body => "a string!!!"})
+      end
+
+      it "should match with regex prefix when required_prefix is present" do
+        canary = mock
+        canary.expects(:lives).at_least(4)
+        
+        bot = a Scamp, :required_prefix => /^Bot\W{1,2}/i
+        bot.behaviour do
+          match(/a string/) {canary.lives}
+        end
+        
+        bot.send(:process_message, {:body => "Bot, a string"})
+        bot.send(:process_message, {:body => "Bot a string"})
+        bot.send(:process_message, {:body => "bot: a string"})
+        bot.send(:process_message, {:body => "Bot: a string oh my!"})
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,5 @@
 require File.expand_path("../lib/scamp", File.dirname(__FILE__))
 require 'mocha'
+RSpec.configure do |config|
+  config.mock_framework = :mocha
+end


### PR DESCRIPTION
Allows you to do:

```
Scamp.new(:required_prefix => "Bot: ")
```

or 

```
Scamp.new(:required_prefix => /^Bot\W{1,2}/i)
```

All matches will first check against the prefix and ignore messages not prefixed.

Comes with specs.

Also comes with a big bonus: Mocha is fixed, so the matcher specs actually run correctly (before, they always passed because rspec wasn't using mocha)
