### PR TITLE
Clean up whitespace for easier code navigation in Vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@ Ruby >= 1.9.2 (At least for the named captures)
 ### The most simple example:
 
     require 'scamp'
-    
+
     scamp = Scamp.new(:api_key => "YOUR API KEY", :subdomain => "yoursubdomain", :verbose => true)
-    
+
     scamp.behaviour do
       # Simple matching based on regex or string:
       match "ping" do
         say "pong"
       end
     end
-    
+
     # Connect and join some rooms
     scamp.connect!([293788, "Monitoring"])
 
@@ -40,69 +40,69 @@ Matchers are tested in order and all that satisfy the match and conditions will 
 
     # Add :verbose => true to get debug output, otherwise the logger will output INFO
     scamp = Scamp.new(:api_key => "YOUR API KEY", :subdomain => "yoursubdomain", :verbose => true)
-    
+
     scamp.behaviour do
-      # 
+      #
       # Simple matching based on regex or string:
-      # 
+      #
       match /^repeat (\w+), (\w+)$/ do
         say "You said #{matches[0]} and #{matches[1]}"
       end
-      
-      # 
+
+      #
       # A special user and room method is available in match blocks.
-      # 
+      #
       match "a user said" do
         say "#{user} said something in room #{room}"
       end
-      
+
       match "Hello!" do
         say "Hi there"
       end
-      
-      # 
+
+      #
       # You can play awesome sounds
-      # 
+      #
       match "ohmy" do
         play "yeah"
       end
-      
-      # 
+
+      #
       # Limit the match to certain rooms, users or both.
-      # 
+      #
       match /^Lets match (.+)$/, :conditions => {:room => "Some Room"} do
         say "Only said if room name mathces /someregex/"
       end
-      
+
       match "some text", :conditions => {:user => "Some User"} do
         say "Only said if user name mathces /someregex/"
       end
-      
+
       match /some other text/, :conditions => {:user => "Some User", :room => 123456} do
         say "You can mix conditions"
       end
-      
-      # 
+
+      #
       # Named captures become avaiable in your match block
-      # 
+      #
       match /^say (?<yousaid>.+)$/ do
         say "You said #{yousaid}"
       end
-      
-      # 
+
+      #
       # You can say multiple times, and you can specify an alternate room.
       # Default behaviour is to 'say' in the room that caused the match.
-      # 
+      #
       match "something" do
         say "#{user} said something in room #{room}"
         say "#{user} said something in room #{room}", 237872
         say "#{user} said something in room #{room}", "System Administration"
       end
-      
-      # 
+
+      #
       # A list of commands is available as command_list this matcher uses it
       # to format a help text
-      # 
+      #
       match "help" do
         max_command_length = command_list.map{|cl| cl.first.to_s }.max_by(&:size).size
         format_string = "%#{max_command_length + 1}s"
@@ -114,7 +114,7 @@ Matchers are tested in order and all that satisfy the match and conditions will 
         EOS
       end
     end
-      
+
     # Connect and join some rooms
     scamp.connect!([293788, "Monitoring"])
 

--- a/examples/bot.rb
+++ b/examples/bot.rb
@@ -12,56 +12,56 @@ scamp.behaviour do
     # Reply in the current room
     say "Match some regex limited to a room condition based on a room id"
   end
-  
+
   # Limit a match to a room condition based on a string
   match "room name check", :conditions => {:room => "Monitoring"} do
     say "Limit a match to a room condition based on a string"
   end
-  
+
   # Limit a match to a user condition based on a string
   match /^user name (.+)$/, :conditions => {:user => "Will Jessop"} do
     say "Limit a match to a user condition based on a string"
   end
-  
+
    # Limit a match to a user condition based on a string
    match "user id check", :conditions => {:user => 774016} do
      say "Limit a match to a user condition based on an ID"
    end
-   
+
    # Limit a match to a room & user condition combined
    match /^something (.+)$/, :conditions => {:room => "Monitoring", :user => "Will Jessop"} do
      # Reply in the current room
      say "Limit a match to a room & user condition combined"
    end
-     
+
    # Match text with a regex, access the captures from the match object
    match /^repeat (\w+), (\w+)$/ do
      say "You said #{matches[0]} and #{matches[1]}"
    end
-   
+
    # Match text with a regex, access the named captures as a method
    match /^say (?<yousaid>.+)$/ do
      say "You said #{yousaid}"
    end
-   
+
    # Simple string match, interpolating the room and user in response.
    match "something" do |data|
      # Send the response to a different room
      say "#{user} said something in room #{room}", "Robot Army"
-     
+
      # Send the response to a different room, using the room ID
      say "#{user} said something in room #{room}", 293788
-     
+
      # Send the response to the originating room
      say "#{user} said something in room #{room}"
    end
-   
+
    # Play some sounds
    match "ohmy" do
      play "yeah"
      play "drama"
    end
-   
+
    match "multi-condition match", :conditions => {:room => [401839, "Monitoring"], :user => ["Will Jessop", "Noah Lorang"]} do
      # Reply in the current room
      say "multi-condition match"

--- a/lib/scamp.rb
+++ b/lib/scamp.rb
@@ -33,23 +33,23 @@ class Scamp
         logger.warn "Scamp initialized with #{k.inspect} => #{v.inspect} but NO UNDERSTAND!"
       end
     end
-    
+
     @rooms_to_join = []
     @rooms = {}
     @user_cache = {}
     @room_cache = {}
     @matchers ||= []
   end
-  
+
   def behaviour &block
     instance_eval &block
   end
-  
+
   def connect!(room_list)
     logger.info "Starting up"
     connect(api_key, room_list)
   end
-  
+
   def command_list
     matchers.map{|m| [m.trigger, m.conditions] }
   end
@@ -78,7 +78,7 @@ class Scamp
     params ||= {}
     matchers << Matcher.new(self, {:trigger => trigger, :action => block, :conditions => params[:conditions], :required_prefix => required_prefix})
   end
-  
+
   def process_message(msg)
     logger.debug "Received message #{msg.inspect}"
     matchers.each do |matcher|

--- a/lib/scamp/action.rb
+++ b/lib/scamp/action.rb
@@ -8,15 +8,15 @@
 
 class Scamp
   class Action
-    
+
     attr_accessor :matches, :bot
-    
+
     def initialize(bot, action, message)
       @bot = bot
       @action = action
       @message = message
     end
-    
+
     def matches=(match)
       @matches = match[1..-1]
       match.names.each do |name|
@@ -26,41 +26,41 @@ class Scamp
         end
       end if match.respond_to?(:names) # 1.8 doesn't support named captures
     end
-    
+
     def room_id
       @message[:room_id]
     end
-    
+
     def room
       bot.room_name_for @message[:room_id]
     end
-    
+
     def user
       bot.username_for(@message[:user_id])
     end
-    
+
     def user_id
       @message[:user_id]
     end
-    
+
     def message
       @message[:body]
     end
-    
+
     def run
       self.instance_eval &@action
     end
-    
+
     private
-    
+
     def command_list
       bot.command_list
     end
-    
+
     def say(msg, room_id_or_name = room_id)
       bot.say(msg, room_id_or_name)
     end
-    
+
     def play(sound, room_id_or_name = room_id)
       bot.play(sound, room_id_or_name)
     end

--- a/lib/scamp/connection.rb
+++ b/lib/scamp/connection.rb
@@ -1,24 +1,24 @@
 class Scamp
   module Connection
     private
-    
+
     def connect(api_key, room_list)
       EventMachine.run do
-        
+
         # Check for rooms to join, and join them
         EventMachine::add_periodic_timer(5) do
           while id = @rooms_to_join.pop
             join_and_stream(id)
           end
         end
-        
+
         populate_room_list do
           logger.debug "Adding #{room_list.join ', '} to list of rooms to join"
           @rooms_to_join = room_list.map{|c| room_id(c) }
         end
-        
+
       end
     end
-      
+
   end
 end

--- a/lib/scamp/matcher.rb
+++ b/lib/scamp/matcher.rb
@@ -1,14 +1,14 @@
 class Scamp
   class Matcher
     attr_accessor :conditions, :trigger, :action, :bot, :required_prefix
-    
+
     def initialize(bot, params = {})
       params ||= {}
       params[:conditions] ||= {}
       params.each { |k,v| send("#{k}=", v) }
       @bot = bot
     end
-    
+
     def attempt(msg)
       return false unless conditions_satisfied_by(msg)
       match = triggered_by(msg[:body])
@@ -22,11 +22,11 @@ class Scamp
       end
       false
     end
-    
+
     private
-    
+
     def triggered_by(message_text)
-      if message_text && required_prefix 
+      if message_text && required_prefix
         message_text = handle_prefix(message_text)
         return false unless message_text
       end
@@ -39,12 +39,12 @@ class Scamp
       end
       false
     end
-    
+
     def handle_prefix(message_text)
       return false unless message_text
       if required_prefix.is_a? String
         if required_prefix == message_text[0...required_prefix.length]
-          message_text.gsub(required_prefix,'') 
+          message_text.gsub(required_prefix,'')
         else
           false
         end
@@ -57,17 +57,17 @@ class Scamp
       else
         false
       end
-    end 
-    
+    end
+
     def run(msg, match = nil)
       action_run = Action.new(bot, action, msg)
       action_run.matches = match if match
       action_run.run
     end
-    
+
     def conditions_satisfied_by(msg)
       bot.logger.debug "Checking message against #{conditions.inspect}"
-      
+
       # item will be :user or :room
       # cond is the int or string value.
       conditions.each do |item, cond|

--- a/lib/scamp/messages.rb
+++ b/lib/scamp/messages.rb
@@ -1,16 +1,16 @@
 class Scamp
   module Messages
-    
+
     def say(message, room_id_or_name)
       send_message(room_id_or_name, message, "Textmessage")
     end
-    
+
     def play(sound, room_id_or_name)
       send_message(room_id_or_name, sound, "SoundMessage")
     end
-    
+
     private
-    
+
     #  curl -vvv -H 'Content-Type: application/json' -d '{"message":{"body":"Yeeeeeaaaaaahh", "type":"Textmessage"}}' -u API_KEY:X https://37s.campfirenow.com/room/293788/speak.json
     def send_message(room_id_or_name, payload, type)
       # post 'speak', :body => {:message => {:body => message, :type => type}}.to_json
@@ -26,6 +26,6 @@ class Scamp
         end
       }
     end
-      
+
   end
 end

--- a/lib/scamp/rooms.rb
+++ b/lib/scamp/rooms.rb
@@ -4,18 +4,18 @@ class Scamp
     # PasteMessage (pre-formatted message, rendered in a fixed-width font),
     # SoundMessage (plays a sound as determined by the message, which can be either “rimshot”, “crickets”, or “trombone”),
     # TweetMessage (a Twitter status URL to be fetched and inserted into the chat)
-    
+
     def paste(text, room)
     end
-    
+
     def upload
     end
-    
+
     def join(room_id)
       logger.info "Joining room #{room_id}"
       url = "https://#{subdomain}.campfirenow.com/room/#{room_id}/join.json"
       http = EventMachine::HttpRequest.new(url).post :head => {'Content-Type' => 'application/json', 'authorization' => [api_key, 'X']}
-      
+
       http.errback { logger.error "Error joining room: #{room_id}" }
       http.callback {
         yield if block_given?
@@ -29,21 +29,21 @@ class Scamp
         return room_id_from_room_name(room_id_or_name)
       end
     end
-    
+
     def room_name_for(room_id)
       data = room_cache_data(room_id)
       return data["name"] if data
       room_id.to_s
     end
-    
+
     private
-    
+
     def room_cache_data(room_id)
       return room_cache[room_id] if room_cache.has_key? room_id
       fetch_room_data(room_id)
       return false
     end
-    
+
     def populate_room_list
       url = "https://#{subdomain}.campfirenow.com/rooms.json"
       http = EventMachine::HttpRequest.new(url).get :head => {'authorization' => [api_key, 'X']}
@@ -84,7 +84,7 @@ class Scamp
         end
       }
     end
-    
+
     def join_and_stream(id)
       join(id) do
         logger.info "Joined room #{id} successfully"
@@ -92,11 +92,11 @@ class Scamp
         stream(id)
       end
     end
-    
+
     def stream(room_id)
       json_parser = Yajl::Parser.new :symbolize_keys => true
       json_parser.on_parse_complete = method(:process_message)
-      
+
       url = "https://streaming.campfirenow.com/room/#{room_id}/live.json"
       # Timeout per https://github.com/igrigorik/em-http-request/wiki/Redirects-and-Timeouts
       http = EventMachine::HttpRequest.new(url, :connect_timeout => 20, :inactivity_timeout => 0).get :head => {'authorization' => [api_key, 'X']}

--- a/lib/scamp/users.rb
+++ b/lib/scamp/users.rb
@@ -7,9 +7,9 @@ class Scamp
       fetch_data_for(user_id)
       return user_id.to_s
     end
-    
+
     private
-    
+
     def fetch_data_for(user_id)
       url = "https://#{subdomain}.campfirenow.com/users/#{user_id}.json"
       http = EventMachine::HttpRequest.new(url).get(:head => {'authorization' => [api_key, 'X'], "Content-Type" => "application/json"})
@@ -25,7 +25,7 @@ class Scamp
         logger.error "Couldn't connect to #{url} to fetch user data for user #{user_id}"
       end
     end
-    
+
     def update_user_cache_with(user_id, data)
       logger.debug "Updated user cache for #{data['name']}"
       user_cache[user_id] = data

--- a/scamp.gemspec
+++ b/scamp.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
-  
+
   s.add_dependency('eventmachine', '~> 1.0.0.beta.4')
   s.add_dependency('yajl-ruby', '~> 0.8.3')
   s.add_dependency('em-http-request', '~> 1.0.0.beta.4')

--- a/spec/lib/scamp_spec.rb
+++ b/spec/lib/scamp_spec.rb
@@ -2,9 +2,9 @@ require "spec_helper"
 
 describe Scamp do
   before do
-    @valid_params = {:api_key => "6124d98749365e3db2c9e5b27ca04db6", :subdomain => "oxygen"} 
+    @valid_params = {:api_key => "6124d98749365e3db2c9e5b27ca04db6", :subdomain => "oxygen"}
     @valid_user_cache_data = {123 => {"name" => "foo"}, 456 => {"name" => "bar"}}
-    
+
     # Stub fetch for room data
     @valid_room_cache_data = {
       123 => {
@@ -19,7 +19,7 @@ describe Scamp do
       }
     }
   end
-  
+
   describe "#initialize" do
     it "should work with valid params" do
       a(Scamp).should be_a(Scamp)
@@ -102,81 +102,81 @@ describe Scamp do
       end
     end
   end
-  
+
   describe "matching" do
-    
+
     context "with conditions" do
       it "should limit matches by room id" do
         canary = mock
         canary.expects(:lives).once
         canary.expects(:bang).never
-        
+
         bot = a Scamp
         bot.behaviour do
           match("a string", :conditions => {:room => 123}) {canary.lives}
           match("a string", :conditions => {:room => 456}) {canary.bang}
         end
-        
+
         bot.send(:process_message, {:room_id => 123, :body => "a string"})
       end
-      
+
       it "should limit matches by room name" do
         canary = mock
         canary.expects(:lives).once
         canary.expects(:bang).never
-        
+
         bot = a Scamp
         bot.behaviour do
           match("a string", :conditions => {:room => "foo"}) {canary.lives}
           match("a string", :conditions => {:room => "bar"}) {canary.bang}
         end
-        
+
         bot.room_cache = @valid_room_cache_data
-        
+
         bot.send(:process_message, {:room_id => 123, :body => "a string"})
       end
-      
+
       it "should limit matches by user id" do
         canary = mock
         canary.expects(:lives).once
         canary.expects(:bang).never
-        
+
         bot = a Scamp
         bot.behaviour do
           match("a string", :conditions => {:user => 123}) {canary.lives}
           match("a string", :conditions => {:user => 456}) {canary.bang}
         end
-        
+
         bot.send(:process_message, {:user_id => 123, :body => "a string"})
       end
-      
+
       it "should limit matches by user name" do
         canary = mock
         canary.expects(:lives).once
         canary.expects(:bang).never
-        
+
         bot = a Scamp
         bot.behaviour do
           match("a string", :conditions => {:user => "foo"}) {canary.lives}
           match("a string", :conditions => {:user => "bar"}) {canary.bang}
         end
-        
+
         bot.user_cache = @valid_user_cache_data
-        
+
         bot.send(:process_message, {:user_id => 123, :body => "a string"})
       end
-      
+
       it "should limit matches by room and user" do
         canary = mock
         canary.expects(:lives).once
         canary.expects(:bang).never
-        
+
         bot = a Scamp
         bot.behaviour do
           match("a string", :conditions => {:room => 123, :user => 123}) {canary.lives}
           match("a string", :conditions => {:room => 456, :user => 456}) {canary.bang}
         end
-        
+
         bot.room_cache = @valid_room_cache_data
         bot.user_cache = @valid_user_cache_data
         bot.send(:process_message, {:room_id => 123, :user_id => 123, :body => "a string"})
@@ -184,70 +184,70 @@ describe Scamp do
         bot.send(:process_message, {:room_id => 456, :user_id => 123, :body => "a string"})
       end
     end
-    
+
     describe "strings" do
       it "should match an exact string" do
         canary = mock
         canary.expects(:lives).once
         canary.expects(:bang).never
-        
+
         bot = a Scamp
         bot.behaviour do
           match("a string") {canary.lives}
           match("another string") {canary.bang}
           match("a string like no other") {canary.bang}
         end
-        
+
         bot.send(:process_message, {:body => "a string"})
       end
-      
+
       it "should not match without prefix when required_prefix is true" do
         canary = mock
         canary.expects(:bang).never
-        
+
         bot = a Scamp, :required_prefix => 'Bot: '
         bot.behaviour do
           match("a string") {canary.bang}
         end
-        
+
         bot.send(:process_message, {:body => "a string"})
       end
 
       it "should match with exact prefix when required_prefix is true" do
         canary = mock
         canary.expects(:lives).once
-        
+
         bot = a Scamp, :required_prefix => 'Bot: '
         bot.behaviour do
           match("a string") {canary.lives}
         end
-        
+
         bot.send(:process_message, {:body => "Bot: a string"})
       end
     end
-    
+
 
     describe "regexes" do
       it "should match a regex" do
         canary = mock
         canary.expects(:ping).twice
-        
+
         bot = a Scamp
         bot.behaviour do
           match /foo/ do
             canary.ping
           end
         end
-        
+
         bot.send(:process_message, {:body => "something foo other thing"})
         bot.send(:process_message, {:body => "foomaster"})
       end
-      
+
       it "should make named captures vailable as methods" do
         canary = mock
         canary.expects(:one).with("first")
         canary.expects(:two).with("the rest of it")
-        
+
         bot = a Scamp
         bot.behaviour do
           match /^please match (?<yousaidthis>\w+) and (?<andthis>.+)$/ do
@@ -255,15 +255,15 @@ describe Scamp do
             canary.two(andthis)
           end
         end
-        
+
         bot.send(:process_message, {:body => "please match first and the rest of it"})
       end
-      
+
       it "should make matches available in an array" do
         canary = mock
         canary.expects(:one).with("first")
         canary.expects(:two).with("the rest of it")
-        
+
         bot = a Scamp
         bot.behaviour do
           match /^please match (\w+) and (.+)$/ do
@@ -271,19 +271,19 @@ describe Scamp do
             canary.two(matches[1])
           end
         end
-        
+
         bot.send(:process_message, {:body => "please match first and the rest of it"})
       end
-      
+
       it "should not match without prefix when required_prefix is present" do
         canary = mock
         canary.expects(:bang).never
-        
+
         bot = a Scamp, :required_prefix => /^Bot[\:,\s]+/i
         bot.behaviour do
           match(/a string/) {canary.bang}
         end
-        
+
         bot.send(:process_message, {:body => "a string"})
         bot.send(:process_message, {:body => "some kind of a string"})
         bot.send(:process_message, {:body => "a string!!!"})
@@ -292,12 +292,12 @@ describe Scamp do
       it "should match with regex prefix when required_prefix is present" do
         canary = mock
         canary.expects(:lives).times(4)
-        
+
         bot = a Scamp, :required_prefix => /^Bot\W{1,2}/i
         bot.behaviour do
           match(/a string/) {canary.lives}
         end
-        
+
         bot.send(:process_message, {:body => "Bot, a string"})
         bot.send(:process_message, {:body => "Bot a string"})
         bot.send(:process_message, {:body => "bot: a string"})
@@ -305,13 +305,13 @@ describe Scamp do
       end
     end
   end
-  
+
   describe "match block" do
     it "should make the room details available to the action block" do
       canary = mock
       canary.expects(:id).with(123)
       canary.expects(:name).with(@valid_room_cache_data[123]["name"])
-      
+
       bot = a Scamp
       bot.behaviour do
         match("a string") {
@@ -319,16 +319,16 @@ describe Scamp do
           canary.name(room)
         }
       end
-      
+
       bot.room_cache = @valid_room_cache_data
       bot.send(:process_message, {:room_id => 123, :body => "a string"})
     end
-    
+
     it "should make the speaking user details available to the action block" do
       canary = mock
       canary.expects(:id).with(123)
       canary.expects(:name).with(@valid_user_cache_data[123]["name"])
-      
+
       bot = a Scamp
       bot.behaviour do
         match("a string") {
@@ -336,29 +336,29 @@ describe Scamp do
           canary.name(user)
         }
       end
-      
+
       bot.user_cache = @valid_user_cache_data
       bot.send(:process_message, {:user_id => 123, :body => "a string"})
     end
-    
+
     it "should make the message said available to the action block" do
       canary = mock
       canary.expects(:message).with("Hello world")
-      
+
       bot = a Scamp
       bot.behaviour do
         match("Hello world") {
           canary.message(message)
         }
       end
-      
+
       bot.send(:process_message, {:body => "Hello world"})
     end
-    
+
     it "should provide a command list" do
       canary = mock
       canary.expects(:commands).with([["Hello world", {}], ["Hello other world", {:room=>123}], [/match me/, {:user=>123}]])
-      
+
       bot = a Scamp
       bot.behaviour do
         match("Hello world") {
@@ -367,10 +367,10 @@ describe Scamp do
         match("Hello other world", :conditions => {:room => 123}) {}
         match(/match me/, :conditions => {:user => 123}) {}
       end
-      
+
       bot.send(:process_message, {:body => "Hello world"})
     end
-    
+
     it "should be able to play a sound to the room the action was triggered in" do
       bot = a Scamp
       bot.behaviour do
@@ -378,7 +378,7 @@ describe Scamp do
           play "yeah"
         }
       end
-      
+
       EM.run_block {
         room_id = 123
         stub_request(:post, "https://#{@valid_params[:subdomain]}.campfirenow.com/room/#{room_id}/speak.json").
@@ -386,21 +386,21 @@ describe Scamp do
             :body => "{\"message\":{\"body\":\"yeah\",\"type\":\"SoundMessage\"}}",
             :headers => {'Authorization'=>[@valid_params[:api_key], 'X'], 'Content-Type'=>'application/json'}
           )
-            
+
         bot.send(:process_message, {:room_id => room_id, :body => "Hello world"})
       }
     end
-    
+
     it "should be able to play a sound to an arbitrary room" do
       play_room = 456
-      
+
       bot = a Scamp
       bot.behaviour do
         match("Hello world") {
           play "yeah", play_room
         }
       end
-      
+
       EM.run_block {
         room_id = 123
         stub_request(:post, "https://#{@valid_params[:subdomain]}.campfirenow.com/room/#{play_room}/speak.json").
@@ -408,11 +408,11 @@ describe Scamp do
             :body => "{\"message\":{\"body\":\"yeah\",\"type\":\"SoundMessage\"}}",
             :headers => {'Authorization'=>[@valid_params[:api_key], 'X'], 'Content-Type'=>'application/json'}
           )
-            
+
         bot.send(:process_message, {:room_id => room_id, :body => "Hello world"})
       }
     end
-    
+
     it "should be able to say a message to the room the action was triggered in" do
       bot = a Scamp
       bot.behaviour do
@@ -420,7 +420,7 @@ describe Scamp do
           say "yeah"
         }
       end
-      
+
       EM.run_block {
         room_id = 123
         stub_request(:post, "https://#{@valid_params[:subdomain]}.campfirenow.com/room/#{room_id}/speak.json").
@@ -428,21 +428,21 @@ describe Scamp do
             :body => "{\"message\":{\"body\":\"yeah\",\"type\":\"Textmessage\"}}",
             :headers => {'Authorization'=>[@valid_params[:api_key], 'X'], 'Content-Type'=>'application/json'}
           )
-            
+
         bot.send(:process_message, {:room_id => room_id, :body => "Hello world"})
       }
     end
-    
+
     it "should be able to say a message to an arbitrary room" do
       play_room = 456
-      
+
       bot = a Scamp
       bot.behaviour do
         match("Hello world") {
           say "yeah", play_room
         }
       end
-      
+
       EM.run_block {
         room_id = 123
         stub_request(:post, "https://#{@valid_params[:subdomain]}.campfirenow.com/room/#{play_room}/speak.json").
@@ -450,7 +450,7 @@ describe Scamp do
             :body => "{\"message\":{\"body\":\"yeah\",\"type\":\"Textmessage\"}}",
             :headers => {'Authorization'=>[@valid_params[:api_key], 'X'], 'Content-Type'=>'application/json'}
           )
-            
+
         bot.send(:process_message, {:room_id => room_id, :body => "Hello world"})
       }
     end
@@ -460,7 +460,7 @@ describe Scamp do
     context "user operations" do
       it "should fetch user data" do
         bot = a Scamp
-        
+
         EM.run_block {
           stub_request(:get, "https://#{@valid_params[:subdomain]}.campfirenow.com/users/123.json").
             with(:headers => {'Authorization'=>[@valid_params[:api_key], 'X'], 'Content-Type'=>'application/json'}).
@@ -468,7 +468,7 @@ describe Scamp do
           bot.username_for(123)
         }
       end
-      
+
       it "should handle HTTP errors fetching user data" do
         mock_logger
         bot = a Scamp
@@ -482,11 +482,11 @@ describe Scamp do
         }
         logger_output.should =~ /ERROR.*Couldn't fetch user data for user 123 with url #{url}, http response from API was 502/
       end
-      
+
       it "should handle network errors fetching user data" do
         mock_logger
         bot = a Scamp
-        
+
         url = "https://#{@valid_params[:subdomain]}.campfirenow.com/users/123.json"
         EM.run_block {
           stub_request(:get, url).
@@ -496,18 +496,18 @@ describe Scamp do
         logger_output.should =~ /ERROR.*Couldn't connect to #{url} to fetch user data for user 123/
       end
     end
-    
+
     context "room operations" do
       before do
         @room_list_url = "https://#{@valid_params[:subdomain]}.campfirenow.com/rooms.json"
         @room_url = "https://#{@valid_params[:subdomain]}.campfirenow.com/room/123.json"
         @stream_url = "https://streaming.campfirenow.com/room/123/live.json"
       end
-      
+
       it "should fetch a room list" do
         mock_logger
         bot = a Scamp
-        
+
         EM.run_block {
           stub_request(:get, @room_list_url).
             with(:headers => {'Authorization'=>[@valid_params[:api_key], 'X']}).
@@ -516,11 +516,11 @@ describe Scamp do
         }
         logger_output.should =~ /DEBUG.*Fetched room list/
       end
-      
+
       it "should handle HTTP errors fetching the room list" do
         mock_logger
         bot = a Scamp
-      
+
         EM.run_block {
           # stub_request(:get, url).
           #   with(:headers => {'Authorization'=>[@valid_params[:api_key], 'X'], 'Content-Type'=>'application/json'}).
@@ -532,7 +532,7 @@ describe Scamp do
         }
         logger_output.should =~ /ERROR.*Couldn't fetch room list with url #{@room_list_url}, http response from API was 502/
       end
-      
+
       it "should handle network errors fetching the room list" do
         mock_logger
         bot = a Scamp
@@ -543,11 +543,11 @@ describe Scamp do
         }
         logger_output.should =~ /ERROR.*Couldn't connect to url #{@room_list_url} to fetch room list/
       end
-      
+
       it "should fetch individual room data" do
         mock_logger
         bot = a Scamp
-        
+
         EM.run_block {
           stub_request(:get, @room_url).
             with(:headers => {'Authorization'=>[@valid_params[:api_key], 'X']}).
@@ -556,7 +556,7 @@ describe Scamp do
         }
         logger_output.should =~ /DEBUG.*Fetched room data for 123/
       end
-      
+
       it "should handle HTTP errors fetching individual room data" do
         mock_logger
         bot = a Scamp
@@ -569,11 +569,11 @@ describe Scamp do
         }
         logger_output.should =~ /ERROR.*Couldn't fetch room data for room 123 with url #{@room_url}, http response from API was 502/
       end
-      
+
       it "should handle network errors fetching individual room data" do
         mock_logger
         bot = a Scamp
-        
+
         EM.run_block {
           stub_request(:get, @room_url).
             with(:headers => {'Authorization'=>[@valid_params[:api_key], 'X']}).to_timeout
@@ -581,12 +581,12 @@ describe Scamp do
         }
         logger_output.should =~ /ERROR.*Couldn't connect to #{@room_url} to fetch room data for room 123/
       end
-      
+
       it "should stream a room"
       it "should handle HTTP errors streaming a room"
       it "should handle network errors streaming a room"
     end
-    
+
     context "message operations" do
       before do
         @message_post_url = "https://#{@valid_params[:subdomain]}.campfirenow.com/room/123/speak.json"
@@ -594,7 +594,7 @@ describe Scamp do
       it "should send a message" do
         mock_logger
         bot = a Scamp
-        
+
         EM.run_block {
           stub_request(:post, @message_post_url).
             with(:headers => {'Authorization'=>[@valid_params[:api_key], 'X'], 'Content-Type' => 'application/json'}).
@@ -603,7 +603,7 @@ describe Scamp do
         }
         logger_output.should =~ /DEBUG.*Posted message "Hi" to room 123/
       end
-      
+
       it "should handle HTTP errors fetching individual room data" do
         mock_logger
         bot = a Scamp
@@ -616,11 +616,11 @@ describe Scamp do
         }
         logger_output.should =~ /ERROR.*Couldn't post message "Hi" to room 123 using url #{@message_post_url}, http response from the API was 502/
       end
-      
+
       it "should handle network errors fetching individual room data" do
         mock_logger
         bot = a Scamp
-        
+
         EM.run_block {
           stub_request(:post, @message_post_url).
             with(:headers => {'Authorization'=>[@valid_params[:api_key], 'X'], 'Content-Type' => 'application/json'}).to_timeout


### PR DESCRIPTION
I was browsing through the code in Vim and noticed some extraneous whitespace that was messing with my Vim navigation chops :P

I apologise in advance if this pull request is totally lame, but it is my first one ever (hopefully the next will be more useful)!

Great project by the way. The timing could not have been better as our company has just adopted Campfire (totally rad) and we were recently talking about creating a bot.
