### PR TITLE
If necessary, bot should ignore itself at all times.

### DIFF
--- a/lib/scamp.rb
+++ b/lib/scamp.rb
@@ -18,7 +18,8 @@ class Scamp
   include Messages
 
   attr_accessor :rooms, :user_cache, :room_cache, :matchers, :api_key, :subdomain,
-                :logger, :verbose, :first_match_only, :required_prefix, :rooms_to_join
+                :logger, :verbose, :first_match_only, :ignore_self, :required_prefix,
+                :rooms_to_join
 
   def initialize(options = {})
     options ||= {}
@@ -81,6 +82,7 @@ class Scamp
   
   def process_message(msg)
     logger.debug "Received message #{msg.inspect}"
+    return false if ignore_self && is_me?(msg[:user_id])
     matchers.each do |matcher|
       break if first_match_only & matcher.attempt(msg)
     end

--- a/lib/scamp/connection.rb
+++ b/lib/scamp/connection.rb
@@ -17,6 +17,9 @@ class Scamp
           @rooms_to_join = room_list.map{|c| room_id(c) }
         end
         
+        # populate bot data separately, in case we are ignoring ourselves
+        fetch_data_for('me')
+        
       end
     end
       

--- a/lib/scamp/users.rb
+++ b/lib/scamp/users.rb
@@ -8,6 +8,15 @@ class Scamp
       return user_id.to_s
     end
     
+    def is_me?(user_id)
+      if user_cache['me']
+        return user_cache['me']['id'] == user_id
+      else
+        fetch_data_for('me')
+        return false        
+      end
+    end
+    
     private
     
     def fetch_data_for(user_id)

--- a/spec/lib/scamp_spec.rb
+++ b/spec/lib/scamp_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe Scamp do
   before do
     @valid_params = {:api_key => "6124d98749365e3db2c9e5b27ca04db6", :subdomain => "oxygen"} 
-    @valid_user_cache_data = {123 => {"name" => "foo"}, 456 => {"name" => "bar"}}
+    @valid_user_cache_data = {123 => {"name" => "foo"}, 456 => {"name" => "bar"}, 'me' => {"name" => "bot", "id" => 123}}
     
     # Stub fetch for room data
     @valid_room_cache_data = {
@@ -182,6 +182,21 @@ describe Scamp do
         bot.send(:process_message, {:room_id => 123, :user_id => 123, :body => "a string"})
         bot.send(:process_message, {:room_id => 123, :user_id => 456, :body => "a string"})
         bot.send(:process_message, {:room_id => 456, :user_id => 123, :body => "a string"})
+      end
+      
+      it "should ignore itself if so requested" do
+        canary = mock
+        canary.expects(:bang).never
+
+        bot = a Scamp
+        bot.user_cache = @valid_user_cache_data
+        bot.ignore_self = true
+        bot.ignore_self.should be_true
+        bot.behaviour do
+          match("a string") {canary.bang}
+        end
+        
+        bot.send(:process_message, {:user_id => 123, :body => "a string"})
       end
     end
     


### PR DESCRIPTION
the :first_match_only parameter doesn't seem to prevent the bot from actually listening to itself (though it does a great job of only running the first matching block).

This branch looks up the authenticated user on connect and stores her data in the user_cache, consulting the cache for every message if :ignore_self => true is passed to the Scamp initialization.
