### PR TITLE
Add a post connection (reactor alive) callback

### DIFF
--- a/lib/scamp.rb
+++ b/lib/scamp.rb
@@ -46,9 +46,9 @@ class Scamp
     instance_eval &block
   end
   
-  def connect!(room_list)
+  def connect!(room_list, &blk)
     logger.info "Starting up"
-    connect(api_key, room_list)
+    connect(api_key, room_list, &blk)
   end
   
   def command_list

--- a/lib/scamp/connection.rb
+++ b/lib/scamp/connection.rb
@@ -2,7 +2,7 @@ class Scamp
   module Connection
     private
     
-    def connect(api_key, room_list)
+    def connect(api_key, room_list, &blk)
       EventMachine.run do
         
         # Check for rooms to join, and join them
@@ -15,6 +15,11 @@ class Scamp
         populate_room_list do
           logger.debug "Adding #{room_list.join ', '} to list of rooms to join"
           @rooms_to_join = room_list.map{|c| room_id(c) }
+
+          # Call a post connection block
+          if block_given?
+            yield
+          end
         end
         
         # populate bot data separately, in case we are ignoring ourselves


### PR DESCRIPTION
Not sure if this is the best place for this, but it's nice to have a post-connection callback that's invoked once the reactor is alive. This allows one to use EM to create timers or join rooms, etc.
