### PR TITLE
Adding in ability to invoke existing matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,15 +74,35 @@ scamp.behaviour do
   # Limit the match to certain rooms, users or both.
   # 
   match /^Lets match (.+)$/, :conditions => {:room => "Some Room"} do
-    say "Only said if room name mathces /someregex/"
+    say "Only said if room name matches /someregex/"
   end
   
   match "some text", :conditions => {:user => "Some User"} do
-    say "Only said if user name mathces /someregex/"
+    say "Only said if user name matches /someregex/"
   end
   
   match /some other text/, :conditions => {:user => "Some User", :room => 123456} do
     say "You can mix conditions"
+  end
+  
+  #
+  # Invoke other existing matchers from your matches.
+  #
+  match 'a basic matcher' do
+    say "Dreafully exciting"
+  end
+  
+  match 'a much more complicated matcher' do
+    invoke "a basic matcher"
+  end
+  
+  match /^a very (<complicated>) regex$/, :alias => 'simple' do
+    complicated ||= 'make sure to assign variables that might be left unassigned'
+    say "Use aliases to simplify invoking complicated matchers"
+  end
+  
+  match 'a simple string' do
+    invoke "simple"
   end
   
   # 

--- a/lib/scamp.rb
+++ b/lib/scamp.rb
@@ -77,7 +77,7 @@ class Scamp
 
   def match trigger, params={}, &block
     params ||= {}
-    matchers << Matcher.new(self, {:trigger => trigger, :action => block, :conditions => params[:conditions], :required_prefix => required_prefix})
+    matchers << Matcher.new(self, {:trigger => trigger, :action => block, :conditions => params[:conditions], :required_prefix => required_prefix, :alias => params[:alias]})
   end
   
   def process_message(msg)

--- a/lib/scamp/action.rb
+++ b/lib/scamp/action.rb
@@ -58,7 +58,7 @@ class Scamp
     end
     
     def invoke(matcher)
-      bot.matchers.find_all{|m| m.trigger == matcher}.each {|m| m.run(message)}
+      bot.matchers.find_all{|m| m.trigger == matcher || (m.alias && m.alias == matcher)}.each {|m| m.run(message)}
     end
     
     def say(msg, room_id_or_name = room_id)

--- a/lib/scamp/action.rb
+++ b/lib/scamp/action.rb
@@ -57,6 +57,10 @@ class Scamp
       bot.command_list
     end
     
+    def invoke(matcher)
+      bot.matchers.find_all{|m| m.trigger == matcher}.each {|m| m.run(message)}
+    end
+    
     def say(msg, room_id_or_name = room_id)
       bot.say(msg, room_id_or_name)
     end

--- a/lib/scamp/matcher.rb
+++ b/lib/scamp/matcher.rb
@@ -1,6 +1,6 @@
 class Scamp
   class Matcher
-    attr_accessor :conditions, :trigger, :action, :bot, :required_prefix
+    attr_accessor :conditions, :trigger, :action, :bot, :required_prefix, :alias
     
     def initialize(bot, params = {})
       params ||= {}

--- a/lib/scamp/matcher.rb
+++ b/lib/scamp/matcher.rb
@@ -23,6 +23,12 @@ class Scamp
       false
     end
     
+    def run(msg, match = nil)
+      action_run = Action.new(bot, action, msg)
+      action_run.matches = match if match
+      action_run.run
+    end
+    
     private
     
     def triggered_by(message_text)
@@ -58,12 +64,6 @@ class Scamp
         false
       end
     end 
-    
-    def run(msg, match = nil)
-      action_run = Action.new(bot, action, msg)
-      action_run.matches = match if match
-      action_run.run
-    end
     
     def conditions_satisfied_by(msg)
       bot.logger.debug "Checking message against #{conditions.inspect}"

--- a/spec/lib/scamp_spec.rb
+++ b/spec/lib/scamp_spec.rb
@@ -246,6 +246,36 @@ describe Scamp do
         bot.send(:process_message, {:body => 'another string'})
         lambda {bot.send(:process_message, {:body => 'a string like no other'})}.should_not raise_error
       end
+      
+      it "should call a matcher by an alias" do
+        canary = mock
+        canary.expects(:lives).twice
+
+        bot = a Scamp
+        bot.behaviour do
+          match('a string', :alias => 'alias1') {invoke('alias2')}
+          match('another string', :alias => 'alias2') {canary.lives}
+          match('a string like no other', :alias => 'alias3') {invoke('another string')}
+        end
+
+        bot.send(:process_message, {:body => 'a string'})
+        bot.send(:process_message, {:body => 'another string'})
+        bot.send(:process_message, {:body => 'a string like no other'})
+      end
+      
+      it "should call a not call a matcher with a nil alias" do
+        canary = mock
+        canary.expects(:lives).once
+
+        bot = a Scamp
+        bot.behaviour do
+          match('a string') {invoke(nil)}
+          match('another string') {canary.lives}
+        end
+
+        bot.send(:process_message, {:body => 'a string'})
+        bot.send(:process_message, {:body => 'another string'})
+      end
     end
     
     describe "strings" do

--- a/spec/lib/scamp_spec.rb
+++ b/spec/lib/scamp_spec.rb
@@ -249,7 +249,7 @@ describe Scamp do
       
       it "should call a matcher by an alias" do
         canary = mock
-        canary.expects(:lives).twice
+        canary.expects(:lives).times(3)
 
         bot = a Scamp
         bot.behaviour do

--- a/spec/lib/scamp_spec.rb
+++ b/spec/lib/scamp_spec.rb
@@ -200,6 +200,54 @@ describe Scamp do
       end
     end
     
+    describe 'invoking' do
+      it "should call an existing string matcher" do
+        canary = mock
+        canary.expects(:lives).twice
+
+        bot = a Scamp
+        bot.behaviour do
+          match('a string') {invoke('another string')}
+          match('another string') {canary.lives}
+        end
+
+        bot.send(:process_message, {:body => 'a string'})
+        bot.send(:process_message, {:body => 'another string'})
+      end
+      
+      it "should call an existing regex matcher" do
+        canary = mock
+        canary.expects(:lives).twice
+
+        bot = a Scamp
+        bot.behaviour do
+          match('a string') {invoke(/another string/)}
+          match /another string/ do 
+            canary.lives
+          end
+        end
+
+        bot.send(:process_message, {:body => 'a string'})
+        bot.send(:process_message, {:body => 'another string'})
+      end
+      
+      it "should fail silently when there's no successful match" do
+        canary = mock
+        canary.expects(:lives).once
+
+        bot = a Scamp
+        bot.behaviour do
+          match('a string') {invoke('nonexistent string')}
+          match('another string') {canary.lives}
+          match('a string like no other') {invoke(/nonexistent regex/)}
+        end
+
+        lambda {bot.send(:process_message, {:body => 'a string'})}.should_not raise_error
+        bot.send(:process_message, {:body => 'another string'})
+        lambda {bot.send(:process_message, {:body => 'a string like no other'})}.should_not raise_error
+      end
+    end
+    
     describe "strings" do
       it "should match an exact string" do
         canary = mock


### PR DESCRIPTION
We wanted to have a matcher for our deploy task that generally matched "Bot deploy" but could specifically match "bot deploy<branch> to <stage>." To simplify this and cut down on copying and pasting, I wrote this invoke stuff in, so that the "bot deploy" task could call "bot deploy master to production."
