### PR TITLE
Add rake, '~> 0.9.2' as a development dependency.

### DIFF
--- a/scamp.gemspec
+++ b/scamp.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency('yajl-ruby', '~> 0.8.3')
   s.add_dependency('em-http-request', '~> 1.0.0.beta.4')
 
+  s.add_development_dependency "rake", "~> 0.9.2"
   s.add_development_dependency "rspec", "~> 2.6.0"
   s.add_development_dependency "mocha", "~> 0.10.0"
   s.add_development_dependency "webmock", "~> 1.7.6"


### PR DESCRIPTION
This allows one to do: `bundle exec rake spec` without bundler
complaining that rake is not in the bundle.
