### PR TITLE
Remove the private protection from the action command methods.

### DIFF
--- a/lib/scamp/action.rb
+++ b/lib/scamp/action.rb
@@ -51,8 +51,6 @@ class Scamp
       self.instance_eval &@action
     end
     
-    private
-    
     def command_list
       bot.command_list
     end


### PR DESCRIPTION
This permits us to do something like:

``` ruby
class Foo
  def do_something(act)
    ...
    act.say "Hello world"
  end
end

foo = Foo.new

scamp.behaviour do
  match "ping" do
    # 'self' is the action object from instance_eval
    foo.do_something(self)
  end
end
```
