### PR TITLE
Don't try to fetch data for a user if the user_id is nil

### DIFF
--- a/lib/scamp/users.rb
+++ b/lib/scamp/users.rb
@@ -20,6 +20,7 @@ class Scamp
     private
     
     def fetch_data_for(user_id)
+      return if user_id.nil?
       url = "https://#{subdomain}.campfirenow.com/users/#{user_id}.json"
       http = EventMachine::HttpRequest.new(url).get(:head => {'authorization' => [api_key, 'X'], "Content-Type" => "application/json"})
       http.callback do


### PR DESCRIPTION
Fixes annoying but mostly harmless errors like `Couldn't fetch user data for user  with url https://37s.campfirenow.com/users/.json, http response from API was 404`
