### PR TITLE
Prevent crash if API sends invalid data

### DIFF
--- a/lib/scamp/rooms.rb
+++ b/lib/scamp/rooms.rb
@@ -99,7 +99,13 @@ class Scamp
       http = EventMachine::HttpRequest.new(url, :connect_timeout => 20, :inactivity_timeout => 0).get :head => {'authorization' => [api_key, 'X']}
       http.errback { logger.error "Couldn't stream room #{room_id} at url #{url}" }
       http.callback { logger.info "Disconnected from #{url}"; rooms_to_join << room_id}
-      http.stream {|chunk| json_parser << chunk }
+      http.stream do |chunk| 
+        begin
+          json_parser << chunk  
+        rescue Yajl::ParseError => e
+          logger.error "Couldn't parse room data for room #{room_id} with url #{url}, http response data was #{chunk[0..50]}..."
+        end
+      end
     end
 
     def room_id_from_room_name(room_name)

--- a/spec/lib/scamp_spec.rb
+++ b/spec/lib/scamp_spec.rb
@@ -662,8 +662,22 @@ describe Scamp do
         }
         logger_output.should =~ /ERROR.*Couldn't connect to #{@room_url} to fetch room data for room 123/
       end
-      
+
       it "should stream a room"
+
+      it "should handle response errors streaming a room" do
+        mock_logger
+        bot = a Scamp
+        
+        EM.run_block {
+          stub_request(:get, @stream_url).
+            with(:headers => {'Authorization'=>[@valid_params[:api_key], 'X']}).
+            to_return(:status => 201, :body => 'foobarbaz', :headers => {})
+            lambda { bot.send(:stream, 123) }.should_not raise_error
+        }
+        logger_output.should =~ /ERROR.*Couldn't parse room data for room 123 with url #{@stream_url}, http response data was foobarbaz.../
+      end
+
       it "should handle HTTP errors streaming a room"
       it "should handle network errors streaming a room"
     end


### PR DESCRIPTION
From time to time Campfire's API seems to send invalid JSON as payload. Seems that usually this is caused by some Rails error and the resulting data is actually a Rails's error page. 

```
bundler/gems/Scamp-8caa3e34aa19/lib/scamp/rooms.rb:102:in `<<': lexical error: invalid char in json text.   (Yajl::ParseError)
                                   <!DOCTYPE html PUBLIC "-//W3C//
```

With this patch the json parse error exception is rescued and the crash can be avoided.
